### PR TITLE
[기타] 개발환경 분리

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,7 +11,7 @@ const __dirname = path.dirname(__filename);
 const envFilePath = path.resolve(
   __dirname,
   "sigmine-frontend-envs/.env.next." +
-    (process.env.NODE_ENV || "development")
+    (process.env.APP_ENV || process.env.NODE_ENV || "development")
 );
 
 // 환경변수 로드

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "APP_ENV=local next dev",
-    "build": "next build",
+    "build:dev": "APP_ENV=development next build",
+    "build:prod": "APP_ENV=production next build",
     "start": "next start",
     "lint": "next lint",
     "test:e2e": "playwright test"


### PR DESCRIPTION
## 🏆 Details

<!-- 실제로 변경한 사항을 설명해주세요.-->

-   개발환경과 운영환경 분리
    1. AWS amplify에 브랜치별로 넣어줄 APP_ENV 설정
    2. amplify.yml에서 APP_ENV별로 다른 빌드 명령어 실행되도록 설정
    3. package.json에서 환경별 빌드 명령어에 브랜치별 APP_ENV 주입되도록 설정